### PR TITLE
Make all adapters send a disconnect notification

### DIFF
--- a/src/HTTP/Request/Adapter/Curl.php
+++ b/src/HTTP/Request/Adapter/Curl.php
@@ -93,6 +93,7 @@ class Curl extends Request\Adapter
     protected function _sendRequest()
     {
         $body = curl_exec($this->curl);
+        $this->_notify('disconnect');
 
         if (false === $body) {
             throw new Request\Exception(

--- a/src/HTTP/Request/Adapter/Filesystem.php
+++ b/src/HTTP/Request/Adapter/Filesystem.php
@@ -54,6 +54,7 @@ class Filesystem extends Request\Adapter
             $body = file_get_contents($actualfile);
             $details['code'] = '200';
         }
+        $this->_notify('disconnect');
         // $this->verb is GET/POST/etc.
         // $this->uri is PEAR2\HTTP\Request\Uri
         // $this->headers is array of headers

--- a/src/HTTP/Request/Adapter/Http.php
+++ b/src/HTTP/Request/Adapter/Http.php
@@ -53,6 +53,7 @@ class Http extends Request\Adapter
         }
 
         $request->send();
+        $this->_notify('disconnect');
         $response = $request->getResponseMessage();
         $body = $response->getBody();
 

--- a/src/HTTP/Request/Adapter/Phpsocket.php
+++ b/src/HTTP/Request/Adapter/Phpsocket.php
@@ -89,6 +89,7 @@ class Phpsocket extends Request\Adapter
         $this->_stream->write($payload);
 
         $this->parse();
+        $this->_notify('disconnect');
 
         $details['code'] = $this->code;
         $details['httpVersion'] = $this->httpVersion;

--- a/src/HTTP/Request/Listener.php
+++ b/src/HTTP/Request/Listener.php
@@ -113,4 +113,3 @@ class Listener
     }
 }
 ?>
-

--- a/tests/headers.002.phpt
+++ b/tests/headers.002.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test of arrau access for PEAR2\HTTP\Request\Headers
+Test of array access for PEAR2\HTTP\Request\Headers
 --FILE--
 <?php
 require_once dirname(__FILE__).'/_setup.php';


### PR DESCRIPTION
All adapters now send a disconnect notification when they're done communicating
with the HTTP server. This notification won't be sent in case an exception is
thrown first, but will still be sent when an HTTP error was received from the
remote server.

Also fixes a trailing line feed in the Listener and a typo in one of the tests.
